### PR TITLE
Restrict GHC bounds

### DIFF
--- a/sequent-core.cabal
+++ b/sequent-core.cabal
@@ -43,7 +43,7 @@ library
                        Language.SequentCore.Simpl.Monad
                        Language.SequentCore.Util
                        Language.SequentCore.WiredIn
-  build-depends:       base >= 4 && < 5, ghc>=7.6, containers, transformers,
+  build-depends:       base >= 4 && < 5, ghc >= 7.8 && < 7.10, containers, transformers,
                          bytestring
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-name-shadowing


### PR DESCRIPTION
Error on GHC 7.6:

```
src/Language/SequentCore/Util.hs:26:37:
    Not in scope: `unsafeGlobalDynFlags'
```

GHC 7.10:

```
src/Language/SequentCore/WiredIn.hs:62:16:
    Not in scope: ‘mkSynTyCon’
    Perhaps you meant one of these:
      ‘mkFunTyCon’ (imported from TyCon),
      ‘mkKindTyCon’ (imported from TyCon),
      ‘mkAlgTyCon’ (imported from TyCon)

src/Language/SequentCore/WiredIn.hs:67:11:
    Not in scope: data constructor ‘SynonymTyCon’
    Perhaps you meant variable ‘mkSynonymTyCon’ (imported from TyCon)
```

I've revised existing versions http://hackage.haskell.org/package/sequent-core-0.5/revisions/ so a new release is only needed if you wish to patch the library to allow other GHC versions.
